### PR TITLE
Update deprecated syntax

### DIFF
--- a/inst/stan/ensemble_model_hierarchical_withdrivers.stan
+++ b/inst/stan/ensemble_model_hierarchical_withdrivers.stan
@@ -90,7 +90,7 @@ functions{
    */
 
 
-  int sq_int(int[] model_num_species, int M){
+  int sq_int(array[] int model_num_species, int M){
     int ret = 0;
     for (i in 1:M){
 	    ret += model_num_species[i] * model_num_species[i];
@@ -98,7 +98,7 @@ functions{
 	  return ret;
   }
 
-  int which_fun_subset(int i, int j, int [,] mod_to_dri){
+  int which_fun_subset(int i, int j, array[,] int mod_to_dri){
     int ret = 0;
     int num = 0;
     while (num < j){

--- a/inst/stan/ensemble_model_withdrivers.stan
+++ b/inst/stan/ensemble_model_withdrivers.stan
@@ -81,7 +81,7 @@ functions{
    */
 
 
-  int sq_int(int[] model_num_species, int M){
+  int sq_int(array[] int model_num_species, int M){
     int ret = 0;
     for (i in 1:M){
 	    ret += model_num_species[i] * model_num_species[i];
@@ -89,7 +89,7 @@ functions{
 	  return ret;
   }
 
-  int which_fun_subset(int i, int j, int [,] mod_to_dri){
+  int which_fun_subset(int i, int j, array[,] int mod_to_dri){
     int ret = 0;
     int num = 0;
     while (num < j){

--- a/inst/stan/ensemble_prior_hierarchical_withdrivers.stan
+++ b/inst/stan/ensemble_prior_hierarchical_withdrivers.stan
@@ -48,7 +48,7 @@ functions{
    */
 
 
-  int sq_int(int[] model_num_species, int M){
+  int sq_int(array[] int model_num_species, int M){
     int ret = 0;
     for (i in 1:M){
 	    ret += model_num_species[i] * model_num_species[i];
@@ -56,7 +56,7 @@ functions{
 	  return ret;
   }
 
-  int which_fun_subset(int i, int j, int [,] mod_to_dri){
+  int which_fun_subset(int i, int j, array[,] int mod_to_dri){
     int ret = 0;
     int num = 0;
     while (num < j){

--- a/inst/stan/ensemble_prior_withdrivers.stan
+++ b/inst/stan/ensemble_prior_withdrivers.stan
@@ -39,7 +39,7 @@ functions{
    */
 
 
-  int sq_int(int[] model_num_species, int M){
+  int sq_int(array[] int model_num_species, int M){
     int ret = 0;
     for (i in 1:M){
 	    ret += model_num_species[i] * model_num_species[i];
@@ -47,7 +47,7 @@ functions{
 	  return ret;
   }
 
-  int which_fun_subset(int i, int j, int [,] mod_to_dri){
+  int which_fun_subset(int i, int j, array[,] int mod_to_dri){
     int ret = 0;
     int num = 0;
     while (num < j){


### PR DESCRIPTION
This PR updates some deprecated array syntax in your Stan models which will break with the next major rstan version.

Thanks!